### PR TITLE
Update simple-lean-js-example.html to HoTT support

### DIFF
--- a/examples/simple-lean-js-example.html
+++ b/examples/simple-lean-js-example.html
@@ -68,7 +68,7 @@ Module.postRun = function () {
  * Initialize the lean.js module.
  */
 console.log( '--- Calling lean_init()...' ); startTimer();
-Module.lean_init();
+Module.lean_init( false ); // or use true for HoTT support
 console.log( '--- lean_init() complete.', checkTimer() );
 /*
  * Import the Lean standard module.


### PR DESCRIPTION
lean_init() now requires a boolean argument for whether to use HoTT (true) or not (false).
This example now calls lean_init() with that argument; without it, Lean will not initialize.
